### PR TITLE
Show all order items

### DIFF
--- a/src/components/admin/OrderManagement.tsx
+++ b/src/components/admin/OrderManagement.tsx
@@ -547,15 +547,32 @@ const OrderManagement: React.FC = () => {
                         </div>
                       </td>
                       <td className="px-4 py-3">
-                        <div className="text-sm text-royal-cream/70">
-                          <p>{getTotalItems(order)} Artikel</p>
-                          <p className="text-xs">
-                            {order.items
-                              .slice(0, 2)
-                              .map((item) => item.name)
-                              .join(", ")}
-                            {order.items.length > 2 && "..."}
+                        <div className="text-sm text-royal-cream/70 max-w-xs">
+                          <p className="font-medium text-royal-cream mb-1">
+                            {getTotalItems(order)} Artikel
                           </p>
+                          <div className="space-y-1 max-h-32 overflow-y-auto">
+                            {order.items.map((item, index) => (
+                              <div key={index} className="flex flex-col text-xs">
+                                <div className="flex items-center justify-between">
+                                  <span className="font-medium text-royal-cream">
+                                    {item.quantity}x {item.name}
+                                  </span>
+                                  <span className="text-royal-gold font-medium">
+                                    {(item.price * item.quantity).toFixed(2)}€
+                                  </span>
+                                </div>
+                                <span className="text-royal-cream/50 text-xs">
+                                  {item.category}
+                                </span>
+                                {item.specialInstructions && (
+                                  <span className="text-royal-gold/70 text-xs italic">
+                                    Anweisung: {item.specialInstructions}
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
                         </div>
                       </td>
                       <td className="px-4 py-3">


### PR DESCRIPTION
Display all order items with full details in the Order Management table to provide a complete overview.

The previous implementation only showed the first two items of an order, followed by an ellipsis (...), requiring users to open a separate modal to view all items. This change directly addresses the user's request to see all selected articles and their details (quantity, price, category, special instructions) directly within the main order list for improved efficiency and oversight.

---
<a href="https://cursor.com/background-agent?bcId=bc-069f72a3-bf60-47ea-92ab-dc1bc1fc4983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-069f72a3-bf60-47ea-92ab-dc1bc1fc4983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

